### PR TITLE
Preloader

### DIFF
--- a/config/initializers/extend_preloading.rb
+++ b/config/initializers/extend_preloading.rb
@@ -1,0 +1,36 @@
+module ExtendedPreloading
+  module RelationExtensions
+    def select_includes(*args)
+      @select_includes_values ||= {}
+      # Parse arguments similar to `includes` method
+      args.each do |arg|
+        case arg
+        when Hash
+          arg.each do |key, value|
+            @select_includes_values[key] = Array(value)
+          end
+        else
+          @select_includes_values[arg] = []
+        end
+      end
+      self
+    end
+
+    # Override the `exec_queries` method to perform our custom preloading before the original logic.
+    def exec_queries(&block)
+      unless @select_includes_values.blank?
+        preload_with_select(@select_includes_values)
+      end
+      super(&block)
+    end
+
+    def preload_with_select(select_includes_values)
+      select_includes_values.each do |association, fields|
+        preload_scope = klass.reflect_on_association(association).klass.select(fields)
+        ActiveRecord::Associations::Preloader.new(records: self, associations: association, scope: preload_scope)
+      end
+    end
+  end
+end
+
+ActiveRecord::Relation.prepend(ExtendedPreloading::RelationExtensions)

--- a/config/initializers/extended_preloader.rb
+++ b/config/initializers/extended_preloader.rb
@@ -1,0 +1,45 @@
+module ExtendedPreloader
+  module AssociationExtensions
+    def run
+      # The 'run' method is what executes the preload. We'll wrap it and modify the loaded records before it returns.
+      super
+      constrain_fields if select_constraints.present?
+    end
+
+    # This will hold our custom select constraints
+    def select_constraints
+      @select_constraints ||= {}
+    end
+
+    # Apply constraints to the loaded records. This is a simple version and can be extended.
+    def constrain_fields
+      if select_constraints.key?(reflection.name)
+        fields = select_constraints[reflection.name]
+        records.each do |record|
+          (record.attributes.keys - fields).each do |key_to_remove|
+            record[key_to_remove] = nil
+          end
+        end
+      end
+    end
+  end
+
+  def initialize(records:, associations:, scope: nil, available_records: [], associate_by_default: true, select_constraints: {})
+    super(records: records, associations: associations, scope: scope, available_records: available_records, associate_by_default: associate_by_default)
+    @select_constraints = select_constraints
+  end
+
+  # Add our custom select constraints to the individual Association preloader
+  def preloader_for(reflection, records, preload_scope)
+    if @select_constraints[reflection.name]
+      preload_scope = reflection.klass.select(@select_constraints[reflection.name])
+    end
+
+    preloader = super
+    preloader.singleton_class.prepend(AssociationExtensions)
+    preloader.select_constraints.merge!(@select_constraints)
+    preloader
+  end
+end
+
+ActiveRecord::Associations::Preloader.prepend(ExtendedPreloader)

--- a/config/initializers/query_methods.rb
+++ b/config/initializers/query_methods.rb
@@ -1,0 +1,40 @@
+module QueryMethod
+  def select(*fields)
+    super
+    fields = process_select_args(fields)
+    spawn._select!(*fields)
+  end
+
+  def process_select_args(fields)
+    fields.flat_map do |field|
+      if field.is_a?(Hash)
+        transform_select_hash_values(field)
+      else
+        field
+      end
+    end
+  end
+
+  def transform_select_hash_values(fields)
+    fields.flat_map do |key, columns_aliases|
+      case columns_aliases
+      when Hash
+        columns_aliases.map do |column, column_alias|
+          arel_column("#{key}.#{column}") do
+            predicate_builder.resolve_arel_attribute(key.to_s, column)
+          end.as(column_alias.to_s)
+        end
+      when Array
+        columns_aliases.map do |column|
+          arel_column("#{key}.#{column}", &:itself)
+        end
+      when String, Symbol
+        arel_column(key.to_s) do
+          predicate_builder.resolve_arel_attribute(klass.table_name, key.to_s)
+        end.as(columns_aliases.to_s)
+      end
+    end
+  end
+end
+
+ActiveRecord::Relation.prepend(QueryMethod)


### PR DESCRIPTION
## Why
As @Jay pointed out last time, the current way of handling PORO does not work well with separate queries or having aliases in queries. Although the work is not wasted, and it would be an extension to this work if it pans out.

As we had anticipated, the new hash syntax introduced in Rails 7.1 does not work with includes, nor does it work with any kind of nested structure. However, the idea of tapping into preload could give us what we need without ours having to remapping back to the nested structure of our domain models.

This is an attempt at utilizing something that's more inherent to Rails to make eliminate the above problems. The main idea is to utilize `ActiveRecord::Association::Preloader `to preload entities and strip out columns that we do not want before the query is sent to the DB.

This is done, as of now, by monkey patching the base `Preloader` class and the `ActiveRecord::Relation` class for the additional ways of adding in includes but with only selected columns.

## How to read
commit 1 for adding in Preloader for the includes
commit 2 for adding in a wrapper to call the new methods
commit 3 for a way to put alias and hash syntax into the select

## TODOs
1. this does not work beyond the first level of nesting
2. select columns on the original table sometimes does not work
3. needs to handle eager loads too

## How it looks
The way it works is that you put what you would normally do with select and joins into a .selective_preload method, to mimic the behavior of a `.select` and a `.preload`. And as you can see in the generated queries, only the id column of the associated entity Comment are selected, and nothing else.

![image (1)](https://github.com/chuan29812/rails7/assets/110938544/999326b7-316f-427d-8263-5534802c3118)
